### PR TITLE
Add 'http' as a supported connection type for the FybrikModule.

### DIFF
--- a/fybrik/fybrik-taxonomy-customize.yaml
+++ b/fybrik/fybrik-taxonomy-customize.yaml
@@ -6,6 +6,7 @@ definitions:
       - $ref: "#/definitions/db2"
       - $ref: "#/definitions/kafka"
       - $ref: "#/definitions/fybrik-arrow-flight"
+      - $ref: "#/definitions/http"
       - $ref: "#/definitions/postgres"
       - $ref: "#/definitions/mysql"
       - $ref: "#/definitions/google-sheets"
@@ -62,6 +63,19 @@ definitions:
       value_deserializer:
         type: string
   fybrik-arrow-flight:
+    type: object
+    properties:
+      hostname:
+        type: string
+      port:
+        type: string
+      scheme:
+        type: string
+    required:
+    - hostname
+    - port
+    - scheme
+  http:
     type: object
     properties:
       hostname:

--- a/helm/README.md
+++ b/helm/README.md
@@ -18,3 +18,9 @@
     kubectl exec -it my-shell -n default -- /root/do_get.sh
     ```
     The 'letter_frequency' dataset is a CSV file found in https://people.sc.fsu.edu/~jburkardt/data/csv/letter_frequency.csv. It contains a table with the frequency of each of the 26 English letters. The helm configuration in `abm/values.sample.yaml` contains the URL for the dataset, as well the name of the docker image used as a connector to obtain this dataset (`airbyte/source-file`).
+
+    Alternatively, you can obtain the same dataset through a REST GET request. This can be done by using the 'curl' utility. First you need to install it. Simply run the following commands:
+    ```bash
+    kubectl exec -it my-shell -n default -- apt-get install -y curl
+    kubectl exec -it my-shell -n default -- curl my-app-fybrik-airbyte-sample-airbyte-module.fybrik-blueprints:79/fybrik-airbyte-sample/letter-frequency
+    ```

--- a/module.yaml
+++ b/module.yaml
@@ -37,4 +37,28 @@ spec:
         - source:
             protocol: file
             dataformat: csv
-
+    - capability: read
+      scope: workload
+      api:
+        connection:
+          name: http
+          http:
+            hostname: "{{ .Release.Name }}.{{ .Release.Namespace }}"
+            port: "79"
+            scheme: grpc
+      supportedInterfaces:
+        - source:
+            protocol: postgres
+            dataformat: csv
+        - source:
+            protocol: mysql
+            dataformat: csv
+        - source:
+            protocol: google-sheets
+            dataformat: csv
+        - source:
+            protocol: us-census
+            dataformat: csv
+        - source:
+            protocol: file
+            dataformat: csv


### PR DESCRIPTION
For this we need to define 'http' in the taxonomy.
Update the 'helm' documentation

Signed-off-by: Doron Chen <cdoron@il.ibm.com>