### PR TITLE
helm chart points to ghcr.io/fybrik/airbyte-module:main

### DIFF
--- a/helm/abm/values.yaml
+++ b/helm/abm/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/fybrik/airbyte-module
-  tag: 0.0.0
+  tag: main
   pullPolicy: null
   pullSecret: null
 


### PR DESCRIPTION
instead of ghcr.io/fybrik/airbyte-module:0.0.0

Signed-off-by: Doron Chen <cdoron@il.ibm.com>