### PR TITLE
Fix for potential timing issue with docker daemon

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get install -y docker.io curl
 EXPOSE 8080 8081
 
 ENTRYPOINT ["python3"]
-CMD ["main.py"]
+CMD ["main.py", "--loglevel", "trace"]
 
 USER ${USER_UID}
 


### PR DESCRIPTION
Tested and it can take an addition 7+ seconds for the docker daemon to be ready after the airbyte module pod is up